### PR TITLE
#12 add rasberry libs needed for arm

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -18,13 +18,16 @@ RUN \
 	gnupg && \
  echo "**** add jellyfin deps *****" && \
  curl -s https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | apt-key add - && \
+ curl -s https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x6587ffd6536b8826e88a62547876ae518cbcf2f2 | apt-key add - && \
  echo 'deb [arch=armhf] https://repo.jellyfin.org/ubuntu bionic main' > /etc/apt/sources.list.d/jellyfin.list && \
+ echo "deb http://ppa.launchpad.net/ubuntu-raspi2/ppa/ubuntu bionic main">> /etc/apt/sources.list.d/raspbins.list && \
  apt-get update && \
  apt-get install -y --no-install-recommends \
 	at \
 	jellyfin-ffmpeg \
 	libfontconfig1 \
 	libfreetype6 \
+	libraspberrypi0 \
 	libssl1.0.0 && \
  echo "**** install jellyfin *****" && \
  if [ -z ${JELLYFIN_RELEASE+x} ]; then \


### PR DESCRIPTION
They added these deps in their latest ffmpeg build but do not include these deps in their repo. 

https://github.com/jellyfin/jellyfin-ffmpeg/releases/tag/v4.2.1-3