### PR TITLE
add nightly tag from their repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,14 +30,12 @@ RUN \
 	mesa-va-drivers && \
  echo "**** install jellyfin *****" && \
  if [ -z ${JELLYFIN_RELEASE+x} ]; then \
-	JELLYFIN_RELEASE=$(curl -sX GET "https://api.github.com/repos/jellyfin/jellyfin/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
+	JELLYFIN="jellyfin-nightly"; \
+ else \
+	JELLYFIN="jellyfin-nightly=${JELLYFIN_RELEASE}"; \
  fi && \
- VERSION=$(echo "${JELLYFIN_RELEASE}" | sed 's/^v//g') && \
- curl -o \
- /tmp/jellyfin.deb -L \
-	"https://github.com/jellyfin/jellyfin/releases/download/v${VERSION}/jellyfin_${VERSION}-1_ubuntu-amd64.deb" && \
- dpkg -i /tmp/jellyfin.deb && \
+ apt-get install -y \
+	${JELLYFIN} && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/* \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -30,14 +30,12 @@ RUN \
 	libssl1.0.0 && \
  echo "**** install jellyfin *****" && \
  if [ -z ${JELLYFIN_RELEASE+x} ]; then \
-	JELLYFIN_RELEASE=$(curl -sX GET "https://api.github.com/repos/jellyfin/jellyfin/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
+	JELLYFIN="jellyfin-nightly"; \
+ else \
+	JELLYFIN="jellyfin-nightly=${JELLYFIN_RELEASE}"; \
  fi && \
- VERSION=$(echo "${JELLYFIN_RELEASE}" | sed 's/^v//g') && \
- curl -o \
- /tmp/jellyfin.deb -L \
-	"https://github.com/jellyfin/jellyfin/releases/download/v${VERSION}/jellyfin_${VERSION}-1_ubuntu-arm64.deb" && \
- dpkg -i /tmp/jellyfin.deb && \
+ apt-get install -y \
+	${JELLYFIN} && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/* \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -33,14 +33,12 @@ RUN \
 	libssl1.0.0 && \
  echo "**** install jellyfin *****" && \
  if [ -z ${JELLYFIN_RELEASE+x} ]; then \
-	JELLYFIN_RELEASE=$(curl -sX GET "https://api.github.com/repos/jellyfin/jellyfin/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
+	JELLYFIN="jellyfin-nightly"; \
+ else \
+	JELLYFIN="jellyfin-nightly=${JELLYFIN_RELEASE}"; \
  fi && \
- VERSION=$(echo "${JELLYFIN_RELEASE}" | sed 's/^v//g') && \
- curl -o \
- /tmp/jellyfin.deb -L \
-	"https://github.com/jellyfin/jellyfin/releases/download/v${VERSION}/jellyfin_${VERSION}-1_ubuntu-armhf.deb" && \
- dpkg -i /tmp/jellyfin.deb && \
+ apt-get install -y \
+	${JELLYFIN} && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/* \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,9 +16,6 @@ pipeline {
     GITHUB_TOKEN=credentials('498b4638-2d02-4ce5-832d-8a57d01d97ab')
     GITLAB_TOKEN=credentials('b6f0f1dd-6952-4cf6-95d1-9c06380283f0')
     GITLAB_NAMESPACE=credentials('gitlab-namespace-id')
-    EXT_GIT_BRANCH = 'master'
-    EXT_USER = 'jellyfin'
-    EXT_REPO = 'jellyfin'
     BUILD_VERSION_ARG = 'JELLYFIN_RELEASE'
     LS_USER = 'linuxserver'
     LS_REPO = 'docker-jellyfin'
@@ -44,7 +41,7 @@ pipeline {
         script{
           env.EXIT_STATUS = ''
           env.LS_RELEASE = sh(
-            script: '''docker run --rm alexeiled/skopeo sh -c 'skopeo inspect docker://docker.io/'${DOCKERHUB_IMAGE}':latest 2>/dev/null' | jq -r '.Labels.build_version' | awk '{print $3}' | grep '\\-ls' || : ''',
+            script: '''docker run --rm alexeiled/skopeo sh -c 'skopeo inspect docker://docker.io/'${DOCKERHUB_IMAGE}':nightly 2>/dev/null' | jq -r '.Labels.build_version' | awk '{print $3}' | grep '\\-ls' || : ''',
             returnStdout: true).trim()
           env.LS_RELEASE_NOTES = sh(
             script: '''cat readme-vars.yml | awk -F \\" '/date: "[0-9][0-9].[0-9][0-9].[0-9][0-9]:/ {print $4;exit;}' | sed -E ':a;N;$!ba;s/\\r{0,1}\\n/\\\\n/g' ''',
@@ -101,23 +98,16 @@ pipeline {
     /* ########################
        External Release Tagging
        ######################## */
-    // If this is a stable github release use the latest endpoint from github to determine the ext tag
-    stage("Set ENV github_stable"){
-     steps{
-       script{
-         env.EXT_RELEASE = sh(
-           script: '''curl -s https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases/latest | jq -r '. | .tag_name' ''',
-           returnStdout: true).trim()
-       }
-     }
-    }
-    // If this is a stable or devel github release generate the link for the build message
-    stage("Set ENV github_link"){
-     steps{
-       script{
-         env.RELEASE_LINK = 'https://github.com/' + env.EXT_USER + '/' + env.EXT_REPO + '/releases/tag/' + env.EXT_RELEASE
-       }
-     }
+    // If this is a custom command to determine version use that command
+    stage("Set tag custom bash"){
+      steps{
+        script{
+          env.EXT_RELEASE = sh(
+            script: ''' curl -sX GET https://repo.jellyfin.org/ubuntu/dists/bionic/main/binary-amd64/Packages |grep -A 7 -m 1 'Package: jellyfin-nightly' | awk -F ': ' '/Version/{print $2;exit}' ''',
+            returnStdout: true).trim()
+            env.RELEASE_LINK = 'custom_command'
+        }
+      }
     }
     // Sanitize the release tag and strip illegal docker or github characters
     stage("Sanitize tag"){
@@ -129,10 +119,10 @@ pipeline {
         }
       }
     }
-    // If this is a master build use live docker endpoints
+    // If this is a nightly build use live docker endpoints
     stage("Set ENV live build"){
       when {
-        branch "master"
+        branch "nightly"
         environment name: 'CHANGE_ID', value: ''
       }
       steps {
@@ -153,7 +143,7 @@ pipeline {
     // If this is a dev build use dev docker endpoints
     stage("Set ENV dev build"){
       when {
-        not {branch "master"}
+        not {branch "nightly"}
         environment name: 'CHANGE_ID', value: ''
       }
       steps {
@@ -226,7 +216,7 @@ pipeline {
     // Use helper containers to render templated files
     stage('Update-Templates') {
       when {
-        branch "master"
+        branch "nightly"
         environment name: 'CHANGE_ID', value: ''
         expression {
           env.CONTAINER_NAME != null
@@ -237,7 +227,7 @@ pipeline {
               set -e
               TEMPDIR=$(mktemp -d)
               docker pull linuxserver/jenkins-builder:latest
-              docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH=master -v ${TEMPDIR}:/ansible/jenkins linuxserver/jenkins-builder:latest 
+              docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH=nightly -v ${TEMPDIR}:/ansible/jenkins linuxserver/jenkins-builder:latest 
               CURRENTHASH=$(grep -hs ^ ${TEMPLATED_FILES} | md5sum | cut -c1-8)
               cd ${TEMPDIR}/docker-${CONTAINER_NAME}
               NEWHASH=$(grep -hs ^ ${TEMPLATED_FILES} | md5sum | cut -c1-8)
@@ -245,7 +235,7 @@ pipeline {
                 mkdir -p ${TEMPDIR}/repo
                 git clone https://github.com/${LS_USER}/${LS_REPO}.git ${TEMPDIR}/repo/${LS_REPO}
                 cd ${TEMPDIR}/repo/${LS_REPO}
-                git checkout -f master
+                git checkout -f nightly
                 cd ${TEMPDIR}/docker-${CONTAINER_NAME}
                 mkdir -p ${TEMPDIR}/repo/${LS_REPO}/.github
                 cp --parents ${TEMPLATED_FILES} ${TEMPDIR}/repo/${LS_REPO}/
@@ -277,7 +267,7 @@ pipeline {
     // Exit the build if the Templated files were just updated
     stage('Template-exit') {
       when {
-        branch "master"
+        branch "nightly"
         environment name: 'CHANGE_ID', value: ''
         environment name: 'FILES_UPDATED', value: 'true'
         expression {
@@ -396,7 +386,7 @@ pipeline {
     // Take the image we just built and dump package versions for comparison
     stage('Update-packages') {
       when {
-        branch "master"
+        branch "nightly"
         environment name: 'CHANGE_ID', value: ''
         environment name: 'EXIT_STATUS', value: ''
       }
@@ -424,7 +414,7 @@ pipeline {
               echo "Package tag sha from current packages in buit container is ${NEW_PACKAGE_TAG} comparing to old ${PACKAGE_TAG} from github"
               if [ "${NEW_PACKAGE_TAG}" != "${PACKAGE_TAG}" ]; then
                 git clone https://github.com/${LS_USER}/${LS_REPO}.git ${TEMPDIR}/${LS_REPO}
-                git --git-dir ${TEMPDIR}/${LS_REPO}/.git checkout -f master
+                git --git-dir ${TEMPDIR}/${LS_REPO}/.git checkout -f nightly
                 cp ${TEMPDIR}/package_versions.txt ${TEMPDIR}/${LS_REPO}/
                 cd ${TEMPDIR}/${LS_REPO}/
                 wait
@@ -448,7 +438,7 @@ pipeline {
     // Exit the build if the package file was just updated
     stage('PACKAGE-exit') {
       when {
-        branch "master"
+        branch "nightly"
         environment name: 'CHANGE_ID', value: ''
         environment name: 'PACKAGE_UPDATED', value: 'true'
         environment name: 'EXIT_STATUS', value: ''
@@ -462,7 +452,7 @@ pipeline {
     // Exit the build if this is just a package check and there are no changes to push
     stage('PACKAGECHECK-exit') {
       when {
-        branch "master"
+        branch "nightly"
         environment name: 'CHANGE_ID', value: ''
         environment name: 'PACKAGE_UPDATED', value: 'false'
         environment name: 'EXIT_STATUS', value: ''
@@ -557,14 +547,14 @@ pipeline {
                 echo $GITLAB_TOKEN | docker login registry.gitlab.com -u LinuxServer.io --password-stdin
                 for PUSHIMAGE in "${QUAYIMAGE}" "${GITHUBIMAGE}" "${GITLABIMAGE}" "${IMAGE}"; do
                   docker tag ${IMAGE}:${META_TAG} ${PUSHIMAGE}:${META_TAG}
-                  docker tag ${PUSHIMAGE}:${META_TAG} ${PUSHIMAGE}:latest
-                  docker push ${PUSHIMAGE}:latest
+                  docker tag ${PUSHIMAGE}:${META_TAG} ${PUSHIMAGE}:nightly
+                  docker push ${PUSHIMAGE}:nightly
                   docker push ${PUSHIMAGE}:${META_TAG}
                 done
                 for DELETEIMAGE in "${QUAYIMAGE}" "${GITHUBIMAGE}" "{GITLABIMAGE}" "${IMAGE}"; do
                   docker rmi \
                   ${DELETEIMAGE}:${META_TAG} \
-                  ${DELETEIMAGE}:latest || :
+                  ${DELETEIMAGE}:nightly || :
                 done
              '''
         }
@@ -607,52 +597,52 @@ pipeline {
                   docker tag ${IMAGE}:amd64-${META_TAG} ${MANIFESTIMAGE}:amd64-${META_TAG}
                   docker tag ${IMAGE}:arm32v7-${META_TAG} ${MANIFESTIMAGE}:arm32v7-${META_TAG}
                   docker tag ${IMAGE}:arm64v8-${META_TAG} ${MANIFESTIMAGE}:arm64v8-${META_TAG}
-                  docker tag ${MANIFESTIMAGE}:amd64-${META_TAG} ${MANIFESTIMAGE}:amd64-latest
-                  docker tag ${MANIFESTIMAGE}:arm32v7-${META_TAG} ${MANIFESTIMAGE}:arm32v7-latest
-                  docker tag ${MANIFESTIMAGE}:arm64v8-${META_TAG} ${MANIFESTIMAGE}:arm64v8-latest
+                  docker tag ${MANIFESTIMAGE}:amd64-${META_TAG} ${MANIFESTIMAGE}:amd64-nightly
+                  docker tag ${MANIFESTIMAGE}:arm32v7-${META_TAG} ${MANIFESTIMAGE}:arm32v7-nightly
+                  docker tag ${MANIFESTIMAGE}:arm64v8-${META_TAG} ${MANIFESTIMAGE}:arm64v8-nightly
                   docker push ${MANIFESTIMAGE}:amd64-${META_TAG}
                   docker push ${MANIFESTIMAGE}:arm32v7-${META_TAG}
                   docker push ${MANIFESTIMAGE}:arm64v8-${META_TAG}
-                  docker push ${MANIFESTIMAGE}:amd64-latest
-                  docker push ${MANIFESTIMAGE}:arm32v7-latest
-                  docker push ${MANIFESTIMAGE}:arm64v8-latest
-                  docker manifest push --purge ${MANIFESTIMAGE}:latest || :
-                  docker manifest create ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:amd64-latest ${MANIFESTIMAGE}:arm32v7-latest ${MANIFESTIMAGE}:arm64v8-latest
-                  docker manifest annotate ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:arm32v7-latest --os linux --arch arm
-                  docker manifest annotate ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:arm64v8-latest --os linux --arch arm64 --variant v8
+                  docker push ${MANIFESTIMAGE}:amd64-nightly
+                  docker push ${MANIFESTIMAGE}:arm32v7-nightly
+                  docker push ${MANIFESTIMAGE}:arm64v8-nightly
+                  docker manifest push --purge ${MANIFESTIMAGE}:nightly || :
+                  docker manifest create ${MANIFESTIMAGE}:nightly ${MANIFESTIMAGE}:amd64-nightly ${MANIFESTIMAGE}:arm32v7-nightly ${MANIFESTIMAGE}:arm64v8-nightly
+                  docker manifest annotate ${MANIFESTIMAGE}:nightly ${MANIFESTIMAGE}:arm32v7-nightly --os linux --arch arm
+                  docker manifest annotate ${MANIFESTIMAGE}:nightly ${MANIFESTIMAGE}:arm64v8-nightly --os linux --arch arm64 --variant v8
                   docker manifest push --purge ${MANIFESTIMAGE}:${META_TAG} || :
                   docker manifest create ${MANIFESTIMAGE}:${META_TAG} ${MANIFESTIMAGE}:amd64-${META_TAG} ${MANIFESTIMAGE}:arm32v7-${META_TAG} ${MANIFESTIMAGE}:arm64v8-${META_TAG}
                   docker manifest annotate ${MANIFESTIMAGE}:${META_TAG} ${MANIFESTIMAGE}:arm32v7-${META_TAG} --os linux --arch arm
                   docker manifest annotate ${MANIFESTIMAGE}:${META_TAG} ${MANIFESTIMAGE}:arm64v8-${META_TAG} --os linux --arch arm64 --variant v8
-                  docker manifest push --purge ${MANIFESTIMAGE}:latest
+                  docker manifest push --purge ${MANIFESTIMAGE}:nightly
                   docker manifest push --purge ${MANIFESTIMAGE}:${META_TAG} 
                 done
                 for LEGACYIMAGE in "${GITHUBIMAGE}" "${QUAYIMAGE}"; do
                   docker tag ${IMAGE}:amd64-${META_TAG} ${LEGACYIMAGE}:amd64-${META_TAG}
                   docker tag ${IMAGE}:arm32v7-${META_TAG} ${LEGACYIMAGE}:arm32v7-${META_TAG}
                   docker tag ${IMAGE}:arm64v8-${META_TAG} ${LEGACYIMAGE}:arm64v8-${META_TAG}
-                  docker tag ${LEGACYIMAGE}:amd64-${META_TAG} ${LEGACYIMAGE}:latest
+                  docker tag ${LEGACYIMAGE}:amd64-${META_TAG} ${LEGACYIMAGE}:nightly
                   docker tag ${LEGACYIMAGE}:amd64-${META_TAG} ${LEGACYIMAGE}:${META_TAG}
-                  docker tag ${LEGACYIMAGE}:arm32v7-${META_TAG} ${LEGACYIMAGE}:arm32v7-latest
-                  docker tag ${LEGACYIMAGE}:arm64v8-${META_TAG} ${LEGACYIMAGE}:arm64v8-latest
+                  docker tag ${LEGACYIMAGE}:arm32v7-${META_TAG} ${LEGACYIMAGE}:arm32v7-nightly
+                  docker tag ${LEGACYIMAGE}:arm64v8-${META_TAG} ${LEGACYIMAGE}:arm64v8-nightly
                   docker push ${LEGACYIMAGE}:amd64-${META_TAG}
                   docker push ${LEGACYIMAGE}:arm32v7-${META_TAG}
                   docker push ${LEGACYIMAGE}:arm64v8-${META_TAG}
-                  docker push ${LEGACYIMAGE}:latest
+                  docker push ${LEGACYIMAGE}:nightly
                   docker push ${LEGACYIMAGE}:${META_TAG}
-                  docker push ${LEGACYIMAGE}:arm32v7-latest
-                  docker push ${LEGACYIMAGE}:arm64v8-latest
+                  docker push ${LEGACYIMAGE}:arm32v7-nightly
+                  docker push ${LEGACYIMAGE}:arm64v8-nightly
                 done
              '''
           sh '''#! /bin/bash
                 for DELETEIMAGE in "${QUAYIMAGE}" "${GITHUBIMAGE}" "${GITLABIMAGE}" "${IMAGE}"; do
                   docker rmi \
                   ${DELETEIMAGE}:amd64-${META_TAG} \
-                  ${DELETEIMAGE}:amd64-latest \
+                  ${DELETEIMAGE}:amd64-nightly \
                   ${DELETEIMAGE}:arm32v7-${META_TAG} \
-                  ${DELETEIMAGE}:arm32v7-latest \
+                  ${DELETEIMAGE}:arm32v7-nightly \
                   ${DELETEIMAGE}:arm64v8-${META_TAG} \
-                  ${DELETEIMAGE}:arm64v8-latest || :
+                  ${DELETEIMAGE}:arm64v8-nightly || :
                 done
                 docker rmi \
                 lsiodev/buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER} \
@@ -664,7 +654,7 @@ pipeline {
     // If this is a public release tag it in the LS Github
     stage('Github-Tag-Push-Release') {
       when {
-        branch "master"
+        branch "nightly"
         expression {
           env.LS_RELEASE != env.EXT_RELEASE_CLEAN + '-ls' + env.LS_TAG_NUMBER
         }
@@ -676,17 +666,17 @@ pipeline {
         sh '''curl -H "Authorization: token ${GITHUB_TOKEN}" -X POST https://api.github.com/repos/${LS_USER}/${LS_REPO}/git/tags \
         -d '{"tag":"'${EXT_RELEASE_CLEAN}'-ls'${LS_TAG_NUMBER}'",\
              "object": "'${COMMIT_SHA}'",\
-             "message": "Tagging Release '${EXT_RELEASE_CLEAN}'-ls'${LS_TAG_NUMBER}' to master",\
+             "message": "Tagging Release '${EXT_RELEASE_CLEAN}'-ls'${LS_TAG_NUMBER}' to nightly",\
              "type": "commit",\
              "tagger": {"name": "LinuxServer Jenkins","email": "jenkins@linuxserver.io","date": "'${GITHUB_DATE}'"}}' '''
         echo "Pushing New release for Tag"
         sh '''#! /bin/bash
-              curl -s https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases/latest | jq '. |.body' | sed 's:^.\\(.*\\).$:\\1:' > releasebody.json
+              echo "Updating to ${EXT_RELEASE_CLEAN}" > releasebody.json
               echo '{"tag_name":"'${EXT_RELEASE_CLEAN}'-ls'${LS_TAG_NUMBER}'",\
-                     "target_commitish": "master",\
+                     "target_commitish": "nightly",\
                      "name": "'${EXT_RELEASE_CLEAN}'-ls'${LS_TAG_NUMBER}'",\
-                     "body": "**LinuxServer Changes:**\\n\\n'${LS_RELEASE_NOTES}'\\n**'${EXT_REPO}' Changes:**\\n\\n' > start
-              printf '","draft": false,"prerelease": false}' >> releasebody.json
+                     "body": "**LinuxServer Changes:**\\n\\n'${LS_RELEASE_NOTES}'\\n**Remote Changes:**\\n\\n' > start
+              printf '","draft": false,"prerelease": true}' >> releasebody.json
               paste -d'\\0' start releasebody.json > releasebody.json.done
               curl -H "Authorization: token ${GITHUB_TOKEN}" -X POST https://api.github.com/repos/${LS_USER}/${LS_REPO}/releases -d @releasebody.json.done'''
       }

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ The architectures supported by this image are:
 | arm64 | arm64v8-latest |
 | armhf | arm32v7-latest |
 
+## Version Tags
+
+This image provides various versions that are available via tags. `latest` tag usually provides the latest stable version. Others are considered under development and caution must be exercised when using them.
+
+| Tag | Description |
+| :----: | --- |
+| latest | Stable Jellyfin releases |
+| nightly | Nightly Jellyfin releases |
 
 ## Usage
 
@@ -259,6 +267,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **30.01.20:** - Add nightly tag.
 * **09.01.20:** - Add Pi OpenMax support.
 * **02.10.19:** - Improve permission fixing for render & dvb devices.
 * **31.07.19:** - Add AMD drivers for vaapi support on x86.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,14 +2,12 @@
 
 # jenkins variables
 project_name: docker-jellyfin
-external_type: github_stable
-release_type: stable
-release_tag: latest
-ls_branch: master
+external_type: na
+custom_version_command: "curl -sX GET https://repo.jellyfin.org/ubuntu/dists/bionic/main/binary-amd64/Packages |grep -A 7 -m 1 'Package: jellyfin-nightly' | awk -F ': ' '/Version/{print $2;exit}'"
+release_type: prerelease
+release_tag: nightly
+ls_branch: nightly
 repo_vars:
-  - EXT_GIT_BRANCH = 'master'
-  - EXT_USER = 'jellyfin'
-  - EXT_REPO = 'jellyfin'
   - BUILD_VERSION_ARG = 'JELLYFIN_RELEASE'
   - LS_USER = 'linuxserver'
   - LS_REPO = 'docker-jellyfin'

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -13,6 +13,12 @@ available_architectures:
   - { arch: "{{ arch_arm64 }}", tag: "arm64v8-latest"}
   - { arch: "{{ arch_armhf }}", tag: "arm32v7-latest"}
 
+# development version
+development_versions: true
+development_versions_items:
+  - { tag: "latest", desc: "Stable Jellyfin releases" }
+  - { tag: "nightly", desc: "Nightly Jellyfin releases" }
+
 # container parameters
 common_param_env_vars_enabled: true #PGID, PUID, etc
 param_container_name: "{{ project_name }}"
@@ -80,6 +86,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "30.01.20:", desc: "Add nightly tag." }
   - { date: "09.01.20:", desc: "Add Pi OpenMax support." }
   - { date: "02.10.19:", desc: "Improve permission fixing for render & dvb devices." }
   - { date: "31.07.19:", desc: "Add AMD drivers for vaapi support on x86." }


### PR DESCRIPTION
Need to enable after merge/build:
https://ci.linuxserver.io/job/External-Triggers/job/jellyfin-nightly-external-trigger/
https://ci.linuxserver.io/job/External-Triggers/job/Package-Triggers/job/jellyfin-nightly-package-trigger/

Merge after build: 
https://github.com/linuxserver/docker-jellyfin/pull/17