### PR TITLE
feat: upgrade to ubuntu focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/ubuntu:bionic
+FROM lsiobase/ubuntu:focal
 
 # set version label
 ARG BUILD_DATE
@@ -18,12 +18,7 @@ RUN \
 	gnupg && \
  echo "**** install jellyfin *****" && \
  curl -s https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | apt-key add - && \
- echo 'deb [arch=amd64] https://repo.jellyfin.org/ubuntu bionic main' > /etc/apt/sources.list.d/jellyfin.list && \
- if [ -z ${JELLYFIN_RELEASE+x} ]; then \
-        JELLYFIN="jellyfin"; \
- else \
-        JELLYFIN="jellyfin=${JELLYFIN_RELEASE}"; \
- fi && \
+ echo 'deb [arch=amd64] https://repo.jellyfin.org/ubuntu focal main' > /etc/apt/sources.list.d/jellyfin.list && \
  apt-get update && \
  apt-get install -y --no-install-recommends \
 	at \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/ubuntu:arm64v8-bionic
+FROM lsiobase/ubuntu:arm64v8-focal
 
 # set version label
 ARG BUILD_DATE
@@ -18,14 +18,7 @@ RUN \
 	gnupg && \
  echo "**** install jellyfin *****" && \
  curl -s https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | apt-key add - && \
- curl -s https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x6587ffd6536b8826e88a62547876ae518cbcf2f2 | apt-key add - && \
- echo 'deb [arch=arm64] https://repo.jellyfin.org/ubuntu bionic main' > /etc/apt/sources.list.d/jellyfin.list && \
- echo "deb http://ppa.launchpad.net/ubuntu-raspi2/ppa/ubuntu bionic main">> /etc/apt/sources.list.d/raspbins.list && \
- if [ -z ${JELLYFIN_RELEASE+x} ]; then \
-	JELLYFIN="jellyfin"; \
- else \
-	JELLYFIN="jellyfin=${JELLYFIN_RELEASE}"; \
- fi && \
+ echo 'deb [arch=arm64] https://repo.jellyfin.org/ubuntu focal main' > /etc/apt/sources.list.d/jellyfin.list && \
  apt-get update && \
  apt-get install -y --no-install-recommends \
 	at \
@@ -34,7 +27,17 @@ RUN \
 	libfreetype6 \
 	libomxil-bellagio0 \
 	libomxil-bellagio-bin \
-	libssl1.0.0 && \
+	libssl1.1 && \
+ echo "**** install jellyfin *****" && \
+ if [ -z ${JELLYFIN_RELEASE+x} ]; then \
+	JELLYFIN_RELEASE=$(curl -sX GET "https://api.github.com/repos/jellyfin/jellyfin/releases/latest" \
+	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
+ fi && \
+ VERSION=$(echo "${JELLYFIN_RELEASE}" | sed 's/^v//g') && \
+ curl -o \
+ /tmp/jellyfin.deb -L \
+	"https://github.com/jellyfin/jellyfin/releases/download/v${VERSION}/jellyfin_${VERSION}-1_ubuntu-arm64.deb" && \
+ dpkg -i /tmp/jellyfin.deb && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/* \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/ubuntu:arm32v7-bionic
+FROM lsiobase/ubuntu:arm32v7-focal
 
 # set version label
 ARG BUILD_DATE
@@ -19,7 +19,7 @@ RUN \
  echo "**** install jellyfin *****" && \
  curl -s https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | apt-key add - && \
  curl -s https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x6587ffd6536b8826e88a62547876ae518cbcf2f2 | apt-key add - && \
- echo 'deb [arch=armhf] https://repo.jellyfin.org/ubuntu bionic main' > /etc/apt/sources.list.d/jellyfin.list && \
+ echo 'deb [arch=armhf] https://repo.jellyfin.org/ubuntu focal main' > /etc/apt/sources.list.d/jellyfin.list && \
  echo "deb http://ppa.launchpad.net/ubuntu-raspi2/ppa/ubuntu bionic main">> /etc/apt/sources.list.d/raspbins.list && \
  if [ -z ${JELLYFIN_RELEASE+x} ]; then \
 	JELLYFIN="jellyfin"; \
@@ -35,7 +35,17 @@ RUN \
 	libomxil-bellagio0 \
 	libomxil-bellagio-bin \
 	libraspberrypi0 \
-	libssl1.0.0 && \
+	libssl1.1 && \
+ echo "**** install jellyfin *****" && \
+ if [ -z ${JELLYFIN_RELEASE+x} ]; then \
+	JELLYFIN_RELEASE=$(curl -sX GET "https://api.github.com/repos/jellyfin/jellyfin/releases/latest" \
+	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
+ fi && \
+ VERSION=$(echo "${JELLYFIN_RELEASE}" | sed 's/^v//g') && \
+ curl -o \
+ /tmp/jellyfin.deb -L \
+	"https://github.com/jellyfin/jellyfin/releases/download/v${VERSION}/jellyfin_${VERSION}-1_ubuntu-armhf.deb" && \
+ dpkg -i /tmp/jellyfin.deb && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/* \


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

## Description:
As GLIB 2.28 is required, we need upgrade to Ubuntu Focal. 
It fixes transcoding in jellyfin.
Closes #30

## Benefits of this PR and context:
At the moment transcoding is not working as libbcm_host.so requires GLIBC_2.8. 
This is the log output when on current Ubuntu Bionic:
```
/usr/lib/jellyfin-ffmpeg/ffmpeg: /lib/arm-linux-gnueabihf/libc.so.6: version `GLIBC_2.28' not found (required by /opt/vc/lib/libbcm_host.so)
```

## How Has This Been Tested?
I've locally built using buildx for linux/amd64, linux/arm64 & linux/arm/v7.

On my RPI4 transcoding is working fine now.
## Source / References:
#30 