### PR TITLE
set web directory path

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **27.05.20:** - Set web directory path.
 * **11.04.20:** - Enable hw decode (mmal) on Raspberry Pi, update readme instructions, add donation info, create missing default transcodes folder.
 * **11.03.20:** - Add v4l2 support on Raspberry Pi; remove optional transcode mapping (location is selected in the gui, defaults to path under `/config`).
 * **30.01.20:** - Add nightly tag.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -99,6 +99,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "27.05.20:", desc: "Set web directory path." }
   - { date: "11.04.20:", desc: "Enable hw decode (mmal) on Raspberry Pi, update readme instructions, add donation info, create missing default transcodes folder." }
   - { date: "11.03.20:", desc: "Add v4l2 support on Raspberry Pi; remove optional transcode mapping (location is selected in the gui, defaults to path under `/config`)." }
   - { date: "30.01.20:", desc: "Add nightly tag." }

--- a/root/etc/services.d/jellyfin/run
+++ b/root/etc/services.d/jellyfin/run
@@ -3,7 +3,8 @@
 export JELLYFIN_DATA_DIR="/config/data" \
 JELLYFIN_CONFIG_DIR="/config" \
 JELLYFIN_LOG_DIR="/config/log" \
-JELLYFIN_CACHE_DIR="/config/cache" 
+JELLYFIN_CACHE_DIR="/config/cache" \
+JELLYFIN_WEB_DIR="/usr/share/jellyfin/web"
 
 # set umask
 UMASK_SET=${UMASK_SET:-022}


### PR DESCRIPTION
closes #44 

required in new nightly releases as the web client can now be decoupled from the server: https://jellyfin.org/docs/general/administration/configuration.html#web-directory