### PR TITLE
new package endpoints for nightly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,9 @@ RUN \
 	mesa-va-drivers && \
  echo "**** install jellyfin *****" && \
  if [ -z ${JELLYFIN_RELEASE+x} ]; then \
-	JELLYFIN="jellyfin-nightly"; \
+	JELLYFIN="jellyfin-server-nightly jellyfin-web-nightly"; \
  else \
-	JELLYFIN="jellyfin-nightly=${JELLYFIN_RELEASE}"; \
+	JELLYFIN="jellyfin-server-nightly=${JELLYFIN_RELEASE} jellyfin-web-nightly=${JELLYFIN_RELEASE}"; \
  fi && \
  apt-get install -y \
 	${JELLYFIN} && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -30,9 +30,9 @@ RUN \
 	libssl1.0.0 && \
  echo "**** install jellyfin *****" && \
  if [ -z ${JELLYFIN_RELEASE+x} ]; then \
-	JELLYFIN="jellyfin-nightly"; \
+	JELLYFIN="jellyfin-server-nightly jellyfin-web-nightly"; \
  else \
-	JELLYFIN="jellyfin-nightly=${JELLYFIN_RELEASE}"; \
+	JELLYFIN="jellyfin-server-nightly=${JELLYFIN_RELEASE} jellyfin-web-nightly=${JELLYFIN_RELEASE}"; \
  fi && \
  apt-get install -y \
 	${JELLYFIN} && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -33,9 +33,9 @@ RUN \
 	libssl1.0.0 && \
  echo "**** install jellyfin *****" && \
  if [ -z ${JELLYFIN_RELEASE+x} ]; then \
-	JELLYFIN="jellyfin-nightly"; \
+	JELLYFIN="jellyfin-server-nightly jellyfin-web-nightly"; \
  else \
-	JELLYFIN="jellyfin-nightly=${JELLYFIN_RELEASE}"; \
+	JELLYFIN="jellyfin-server-nightly=${JELLYFIN_RELEASE} jellyfin-web-nightly=${JELLYFIN_RELEASE}"; \
  fi && \
  apt-get install -y \
 	${JELLYFIN} && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,7 @@ pipeline {
       steps{
         script{
           env.EXT_RELEASE = sh(
-            script: ''' curl -sX GET https://repo.jellyfin.org/ubuntu/dists/bionic/main/binary-amd64/Packages |grep -A 7 -m 1 'Package: jellyfin-nightly' | awk -F ': ' '/Version/{print $2;exit}' ''',
+            script: ''' curl -sX GET https://repo.jellyfin.org/ubuntu/dists/bionic/main/binary-amd64/Packages |grep -A 7 -m 1 'Package: jellyfin-server-nightly' | awk -F ': ' '/Version/{print $2;exit}' ''',
             returnStdout: true).trim()
             env.RELEASE_LINK = 'custom_command'
         }

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -3,7 +3,7 @@
 # jenkins variables
 project_name: docker-jellyfin
 external_type: na
-custom_version_command: "curl -sX GET https://repo.jellyfin.org/ubuntu/dists/bionic/main/binary-amd64/Packages |grep -A 7 -m 1 'Package: jellyfin-nightly' | awk -F ': ' '/Version/{print $2;exit}'"
+custom_version_command: "curl -sX GET https://repo.jellyfin.org/ubuntu/dists/bionic/main/binary-amd64/Packages |grep -A 7 -m 1 'Package: jellyfin-server-nightly' | awk -F ': ' '/Version/{print $2;exit}'"
 release_type: prerelease
 release_tag: nightly
 ls_branch: nightly


### PR DESCRIPTION
Looks like package structure change separating web and server. Would expect this to hit stable at some point. 

After merge and build please enable the updated tirgger: 
https://ci.linuxserver.io/job/External-Triggers/job/jellyfin-nightly-external-trigger/