### PR TITLE
Documentation should call out DLNA and auto-discovery ports as optonal 

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,21 @@ Will set the environment variable `PASSWORD` based on the contents of the `/run/
 For all of our images we provide the ability to override the default umask settings for services started within the containers using the optional `-e UMASK=022` setting.
 Keep in mind umask is not chmod it subtracts from permissions based on it's value it does not add. Please read up [here](https://en.wikipedia.org/wiki/Umask) before asking for support.
 
+## Optional Parameters
+
+The [official documentation for ports](https://jellyfin.org/docs/general/networking/index.html) has several additional ports that can provide auto discovery.
+
+Service Discovery (1900) Since client auto-discover would break if this option were configurable, you cannot change this in the settings at this time. DLNA also uses this port and is required to be in the local subnet.
+
+Client Discovery (7359 UDP) Allows clients to discover Jellyfin on the local network. A broadcast message to this port with Who is JellyfinServer? will get a JSON response that includes the server address, ID, and name.
+
+
+```
+  -p 7359:7359/udp \
+  -p 1900:1900/udp \
+
+```
+
 ## User / Group Identifiers
 
 When using volumes (`-v` flags) permissions issues can arise between the host OS and the container, we avoid this issue by allowing you to specify the user `PUID` and group `PGID`.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -51,7 +51,18 @@ opt_param_devices:
 opt_param_usage_include_ports: true
 opt_param_ports:
   - { external_port: "8920", internal_port: "8920", port_desc: "Https webUI (you need to set up your own certificate)." }
+optional_parameters: |
+The [official documentation for ports](https://jellyfin.org/docs/general/networking/index.html) has several additional ports that can provide auto discovery.
 
+Service Discovery (1900) Since client auto-discover would break if this option were configurable, you cannot change this in the settings at this time. DLNA also uses this port and is required to be in the local subnet.
+
+Client Discovery (7359 UDP) Allows clients to discover Jellyfin on the local network. A broadcast message to this port with Who is JellyfinServer? will get a JSON response that includes the server address, ID, and name.
+
+
+```
+  -p 7359:7359/udp \
+  -p 1900:1900/udp \
+```
 
 # application setup block
 app_setup_block_enabled: true


### PR DESCRIPTION
Add optional parameters letting users know about Service Discovery and Auto Discovery

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	
------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
Update README to include additional ports available in jellyfin 

## Benefits of this PR and context:
https://github.com/linuxserver/docker-jellyfin/issues/59

This has come up in support channels and linuxserver's own documentation does not make it clear that this is available. 

## How Has This Been Tested?
Users report DLNA is now working

## Source / References:
https://jellyfin.org/docs/general/networking/index.html
