### PR TITLE
custom trigger to limit builds to every 6 hrs

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  external-trigger-nightly-customized:
+  external-trigger-nightly:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.3
@@ -65,7 +65,7 @@ jobs:
           elif [ $(curl -s https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-jellyfin/job/nightly/lastBuild/api/json | jq -r '.building') == "true" ]; then
             echo "**** New version ${EXT_RELEASE} found; but there already seems to be an active build on Jenkins; exiting ****"
             exit 0
-          elif [[ $(( $(date +%s%3N) - $(curl -s https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-jellyfin/job/nightly/lastBuild/api/json | jq -r '.timestamp')  )) -lt 21600000 ]]; then
+          elif [[ $(( $(date +%s%3N) - $(curl -s https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-jellyfin/job/nightly/lastBuild/api/json | jq -r '.timestamp')  )) -lt $(( 6 * 3600000 )) ]]; then
             echo "**** New version ${EXT_RELEASE} found; but the last build was less than 6 hours ago; skipping trigger ****"
             exit 0
           else

--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  external-trigger-nightly:
+  external-trigger-nightly-customized:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.3
@@ -64,6 +64,9 @@ jobs:
             exit 0
           elif [ $(curl -s https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-jellyfin/job/nightly/lastBuild/api/json | jq -r '.building') == "true" ]; then
             echo "**** New version ${EXT_RELEASE} found; but there already seems to be an active build on Jenkins; exiting ****"
+            exit 0
+          elif [[ $(( $(date +%s%3N) - $(curl -s https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-jellyfin/job/nightly/lastBuild/api/json | jq -r '.timestamp')  )) -lt 21600000 ]]; then
+            echo "**** New version ${EXT_RELEASE} found; but the last build was less than 6 hours ago; skipping trigger ****"
             exit 0
           else
             echo "**** New version ${EXT_RELEASE} found; old version was ${IMAGE_VERSION}. Triggering new build ****"

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -7,6 +7,7 @@ custom_version_command: "curl -sX GET https://repo.jellyfin.org/ubuntu/dists/foc
 release_type: prerelease
 release_tag: nightly
 ls_branch: nightly
+custom_external_trigger: true
 repo_vars:
   - BUILD_VERSION_ARG = 'JELLYFIN_RELEASE'
   - LS_USER = 'linuxserver'

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -7,7 +7,7 @@ custom_version_command: "curl -sX GET https://repo.jellyfin.org/ubuntu/dists/foc
 release_type: prerelease
 release_tag: nightly
 ls_branch: nightly
-custom_external_trigger: true
+external_trigger_delay_hours: 6
 repo_vars:
   - BUILD_VERSION_ARG = 'JELLYFIN_RELEASE'
   - LS_USER = 'linuxserver'


### PR DESCRIPTION
~~This is a custom trigger and it won't be overwritten by the jenkins builder due to the `custom_external_trigger: true` set in jenkins-vars.yml~~ Ended up adding a new var, `external_trigger_delay_hours`, to jenkins-vars.yml, which will introduce the following functionality:

This trigger will query the jenkins api for the latest nightly branch build and if it hasn't been more than 6 hours since, it will skip the trigger.