### PR TITLE
Ensure hardware acceleration devices have proper group permissions

### DIFF
--- a/root/etc/cont-init.d/40-gid-video
+++ b/root/etc/cont-init.d/40-gid-video
@@ -4,6 +4,7 @@ FILES=$(find /dev/dri /dev/dvb /dev/vchiq /dev/vc-mem /dev/video1? -type c -prin
 
 for i in $FILES
 do
+	chmod g+rwx "$i"
 	VIDEO_GID=$(stat -c '%g' "$i")
 	if ! id -G abc | grep -qw "$VIDEO_GID"; then
 		VIDEO_NAME=$(getent group "${VIDEO_GID}" | awk -F: '{print $1}')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-jellyfin/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
This fixes issue #111 (and probably a lot of cases of #26 ) by ensuring all detected hardware acceleration devices have group permissions set (g+rwx). This is required for hardware acceleration to work if the docker host system does not have any group permissions set for them (these get replicated into the docker container) 

## Benefits of this PR and context:
Fixes hardware acceleration for many users, including those with synology devices which by default don't have group permissions set for the intel quicksync device (/dev/dri/renderD128)

## How Has This Been Tested?
Yes - single line of code.

## Source / References:
See #111 