### PR TITLE
Allow configuration override.

### DIFF
--- a/root/etc/services.d/jellyfin/run
+++ b/root/etc/services.d/jellyfin/run
@@ -1,9 +1,17 @@
 #!/usr/bin/with-contenv bash
 
-export JELLYFIN_DATA_DIR="/config/data" \
-JELLYFIN_CONFIG_DIR="/config" \
-JELLYFIN_LOG_DIR="/config/log" \
-JELLYFIN_CACHE_DIR="/config/cache"
+echo "
+JELLYFIN_DATA_DIR: ${JELLYFIN_DATA_DIR:=/config/data}
+JELLYFIN_CONFIG_DIR: ${JELLYFIN_CONFIG_DIR:=/config}
+JELLYFIN_CACHE_DIR: ${JELLYFIN_CACHE_DIR:=/config/cache}
+JELLYFIN_LOG_DIR: ${JELLYFIN_LOG_DIR:=/config/log}
+"
+
+export \
+JELLYFIN_DATA_DIR \
+JELLYFIN_CONFIG_DIR \
+JELLYFIN_CACHE_DIR \
+JELLYFIN_LOG_DIR
 
 if [ -n "${UMASK_SET}" ] && [ -z "${UMASK}" ]; then
   echo -e "You are using a legacy method of defining umask\nplease update your environment variable from UMASK_SET to UMASK\nto keep the functionality after July 2021"


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-jellyfin/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
This change let's me override the server config with JELLYFIN_*_DIR env vars, so I'm free to relocate specific Jellyfin dirs instead of being forced into a predefined structure.

Also, I expect the env variables mentioned by the [Jellyfin documentation](https://jellyfin.org/docs/general/administration/configuration.html#server-paths) to work with this image as well.

## Benefits of this PR and context:
JELLYFIN_*_DIR env variables allow the users to relocate the data, config, cache and log directories, if they want to. If those variables are not specified, it works the same way as before.

## How Has This Been Tested?

1. Try to use configuration env vars:
    ~~~
    docker run --name jellyfin_test \
      -v /tmp/jellyfin-data:/data \
      -v /tmp/jellyfin-config:/config \
      -v /tmp/jellyfin-cache:/cache \
      -v /tmp/jellyfin-logs:/logs \
      -e JELLYFIN_DATA_DIR=/data \
      -e JELLYFIN_CONFIG_DIR=/config \
      -e JELLYFIN_CACHE_DIR=/cache \
      -e JELLYFIN_LOG_DIR=/logs \
      ghcr.io/linuxserver/jellyfin
    ~~~

2. The logs clearly show they are not picked up:
    ~~~
    Main: Environment Variables: ["[JELLYFIN_CONFIG_DIR, /config]", "[JELLYFIN_DATA_DIR, /config/data]", "[JELLYFIN_LOG_DIR, /config/log]", "[JELLYFIN_CACHE_DIR, /config/cache]"]
    ~~~

3. Run `bash` in container and make proposed change to startup script.
    ~~~
    docker exec -it jellyfin_test /bin/bash
    # ... edit file and save it ...
    ~~~

4. Restart container:
    ~~~
    docker stop jellyfin_test && docker start -a jellyfin_test
    ~~~

5. Log shows the environment variables are picked up:
    ~~~
    Main: Environment Variables: ["[JELLYFIN_CACHE_DIR, /cache]", "[JELLYFIN_LOG_DIR, /logs]", "[JELLYFIN_DATA_DIR, /data]", "[JELLYFIN_CONFIG_DIR, /config]"]
    ~~~

## Source / References:
N/A