### PR TITLE
Switch to custom jellyfin-ffmpeg that contains full feature Intel iHD driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ LABEL maintainer="thelamer"
 ARG DEBIAN_FRONTEND="noninteractive"
 ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
+# add jellyfin-ffmpeg with full feature iHD driver included
+COPY amd64/ /tmp
+
 RUN \
   echo "**** install packages ****" && \
   apt-get update && \
@@ -19,8 +22,6 @@ RUN \
   echo "**** install jellyfin *****" && \
   curl -s https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | apt-key add - && \
   echo 'deb [arch=amd64] https://repo.jellyfin.org/ubuntu focal main' > /etc/apt/sources.list.d/jellyfin.list && \
-  curl -s https://repositories.intel.com/graphics/intel-graphics.key | apt-key add - && \
-  echo 'deb [arch=amd64] https://repositories.intel.com/graphics/ubuntu focal main' > /etc/apt/sources.list.d/intel-graphics.list && \
   if [ -z ${JELLYFIN_RELEASE+x} ]; then \
     JELLYFIN="jellyfin-server"; \
   else \
@@ -29,14 +30,14 @@ RUN \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     at \
-    intel-media-va-driver-non-free \
     ${JELLYFIN} \
-    jellyfin-ffmpeg \
     jellyfin-web \
     libfontconfig1 \
     libfreetype6 \
     libssl1.1 \
     mesa-va-drivers && \
+  apt-get install -y -f --no-install-recommends \
+    /tmp/ffmpeg/jellyfin-ffmpeg_*-focal_amd64.deb && \
   echo "**** cleanup ****" && \
   rm -rf \
     /tmp/* \

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **05.01.22:** - Switch to custom jellyfin-ffmpeg to fix the mismatched libva error.
 * **25.12.21:** - Fix video device group perms error message.
 * **10.12.21:** - Rework readme, disable template sync.
 * **22.09.21:** - Pull only the server, web and ffmpeg packages instead of the wrapper.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-jellyfin/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Switch to custom `jellyfin-ffmpeg` package that contains full feature Intel iHD driver.

I will continue to maintain this package whenever the upstream tags a new release.

You can also build it by removing the commented out lines around
https://github.com/jellyfin/jellyfin-ffmpeg/blob/883570db52d230f7f9ab6c532069002d7a5ed90c/docker-build.sh#L165

```
apt install git mmv make docker.io
systemctl start docker
git clone https://github.com/jellyfin/jellyfin-ffmpeg.git
cd jellyfin-ffmpeg
mkdir target
./build [distro] [arch] target
```

The `intel-media-driver-non-free` package from [intel repo](https://dgpu-docs.intel.com/installation-guides/ubuntu/ubuntu-focal.html) is always linked against their latest `libva`, which will break the QSV/VAAPI support in our ffmpeg over time.

```
$ dpkg -c jellyfin-ffmpeg_4.4.1-1-focal_amd64.deb
drwxr-xr-x root/root         0 2022-01-04 02:07 ./
drwxr-xr-x root/root         0 2022-01-04 02:07 ./usr/
drwxr-xr-x root/root         0 2022-01-04 02:07 ./usr/lib/
drwxr-xr-x root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/
-rwxr-xr-x root/root  24752032 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/ffmpeg
-rwxr-xr-x root/root  24551472 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/ffprobe
drwxr-xr-x root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/
drwxr-xr-x root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/dri/
-rw-r--r-- root/root   8710120 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/dri/i965_drv_video.so
-rw-r--r-- root/root  36941616 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/dri/iHD_drv_video.so
-rw-r--r-- root/root   1597832 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libdav1d.so
-rw-r--r-- root/root   1597832 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libdav1d.so.5
-rw-r--r-- root/root   1597832 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libdav1d.so.5.1.1
-rw-r--r-- root/root    591336 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libigdgmm.so.12.0.0
-rw-r--r-- root/root    167032 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libigfxcmrt.so.7.2.0
-rw-r--r-- root/root     63728 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libmfx.so.1.35
-rw-r--r-- root/root  14584624 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libmfxhw64.so.1.35
-rw-r--r-- root/root     14600 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libva-drm.so.2.1400.0
-rw-r--r-- root/root    223960 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libva.so.2.1400.0
-rw-r--r-- root/root    842712 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libzimg.so.2.0.0
drwxr-xr-x root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/mfx/
-rw-r--r-- root/root  11246336 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/mfx/libmfx_h264la_hw64.so
-rw-r--r-- root/root     14544 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/mfx/libmfx_hevc_fei_hw64.so
-rw-r--r-- root/root     14552 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/mfx/libmfx_hevcd_hw64.so
-rw-r--r-- root/root     14544 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/mfx/libmfx_hevce_hw64.so
-rw-r--r-- root/root     14552 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/mfx/libmfx_vp8d_hw64.so
-rw-r--r-- root/root     14552 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/mfx/libmfx_vp9d_hw64.so
-rw-r--r-- root/root     14544 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/mfx/libmfx_vp9e_hw64.so
-rw-r--r-- root/root      1561 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/mfx/plugins.cfg
drwxr-xr-x root/root         0 2022-01-04 02:07 ./usr/share/
drwxr-xr-x root/root         0 2022-01-04 02:07 ./usr/share/doc/
drwxr-xr-x root/root         0 2022-01-04 02:07 ./usr/share/doc/jellyfin-ffmpeg/
-rw-r--r-- root/root     13030 2022-01-04 02:07 ./usr/share/doc/jellyfin-ffmpeg/changelog.Debian.gz
-rw-r--r-- root/root     45943 2021-01-25 19:14 ./usr/share/doc/jellyfin-ffmpeg/copyright
lrwxrwxrwx root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libigdgmm.so -> libigdgmm.so.12
lrwxrwxrwx root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libigdgmm.so.12 -> libigdgmm.so.12.0.0
lrwxrwxrwx root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libigfxcmrt.so -> libigfxcmrt.so.7
lrwxrwxrwx root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libigfxcmrt.so.7 -> libigfxcmrt.so.7.2.0
lrwxrwxrwx root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libmfx.so -> libmfx.so.1
lrwxrwxrwx root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libmfx.so.1 -> libmfx.so.1.35
lrwxrwxrwx root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libmfxhw64.so -> libmfxhw64.so.1
lrwxrwxrwx root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libmfxhw64.so.1 -> libmfxhw64.so.1.35
lrwxrwxrwx root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libva-drm.so -> libva-drm.so.2.1400.0
lrwxrwxrwx root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libva-drm.so.2 -> libva-drm.so.2.1400.0
lrwxrwxrwx root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libva.so -> libva.so.2.1400.0
lrwxrwxrwx root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libva.so.2 -> libva.so.2.1400.0
lrwxrwxrwx root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libzimg.so -> libzimg.so.2.0.0
lrwxrwxrwx root/root         0 2022-01-04 02:07 ./usr/lib/jellyfin-ffmpeg/lib/libzimg.so.2 -> libzimg.so.2.0.0
```

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
- Solve the mismatched `libva` version errors.
- New upstream jellyfin-ffmpeg 4.4.1-1 release.
#107
#109
#115
#129
https://github.com/jellyfin/jellyfin/issues/5993

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Intel QSV/VAAPI HWA + OpenCL/VPP Tone-mapping are all verified with `jellyfin-ffmpeg` 4.4.1-1.

I'm the main maintainer of `jellyfin-ffmpeg` in the past two years, many [HWA improvements](https://github.com/jellyfin/jellyfin/pull/6934) have been made in this new [ffmpeg](https://github.com/jellyfin/jellyfin-ffmpeg/pull/76) and the upcoming Jellyfin 10.8 release. Hope everyone who uses linuxserver container can enjoy it!

