### PR TITLE
Switch to jellyfin-ffmpeg5 for nightly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,6 @@ LABEL maintainer="thelamer"
 ARG DEBIAN_FRONTEND="noninteractive"
 ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
-# set Intel iHD driver versions
-# https://dgpu-docs.intel.com/releases/index.html
-ARG INTEL_LIBVA_VER="2.13.0+i643~u20.04"
-ARG INTEL_GMM_VER="21.3.3+i643~u20.04"
-ARG INTEL_iHD_VER="21.4.1+i643~u20.04"
-
 RUN \
   echo "**** install packages ****" && \
   apt-get update && \
@@ -26,8 +20,6 @@ RUN \
   curl -s https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | apt-key add - && \
   echo 'deb [arch=amd64] https://repo.jellyfin.org/ubuntu focal main' > /etc/apt/sources.list.d/jellyfin.list && \
   echo 'deb [arch=amd64] https://repo.jellyfin.org/ubuntu focal unstable' >> /etc/apt/sources.list.d/jellyfin.list && \
-  curl -s https://repositories.intel.com/graphics/intel-graphics.key | apt-key add - && \
-  echo 'deb [arch=amd64] https://repositories.intel.com/graphics/ubuntu focal main' > /etc/apt/sources.list.d/intel-graphics.list && \
   if [ -z ${JELLYFIN_RELEASE+x} ]; then \
     JELLYFIN="jellyfin-server"; \
   else \
@@ -36,11 +28,8 @@ RUN \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     at \
-    libva2="${INTEL_LIBVA_VER}" \
-    libigdgmm11="${INTEL_GMM_VER}" \
-    intel-media-va-driver-non-free="${INTEL_iHD_VER}" \
     ${JELLYFIN} \
-    jellyfin-ffmpeg \
+    jellyfin-ffmpeg5 \
     jellyfin-web \
     libfontconfig1 \
     libfreetype6 \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -31,7 +31,7 @@ RUN \
   apt-get install -y --no-install-recommends \
     at \
     ${JELLYFIN} \
-    jellyfin-ffmpeg \
+    jellyfin-ffmpeg5 \
     jellyfin-web \
     libfontconfig1 \
     libfreetype6 \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -31,7 +31,7 @@ RUN \
   apt-get install -y --no-install-recommends \
     at \
     ${JELLYFIN} \
-    jellyfin-ffmpeg \
+    jellyfin-ffmpeg5 \
     jellyfin-web \
     libfontconfig1 \
     libfreetype6 \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-jellyfin/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Jellyfin 10.7.x and older are incompatible with FFmpeg 5.x due to a breaking
API change. So we edit the package name of our patched ffmpeg to jellyfin-ffmpeg5.

## Benefits of this PR and context:
- Remove the pinned Intel drivers since we have included their latest versions in jellyfin-ffmpeg since 4.4.1-2.
- Add [Dolby Vision Profile 5 and 8 to SDR tone-mapping](https://www.reddit.com/r/jellyfin/comments/v2nudu/dolby_vision_to_sdr_hwa_tonemapping_is_coming/) support via OpenCL/CUDA on Intel/AMD and Nvidia.
- Add support for Vulkan filters and related libs for future use on AMD VAAPI.
- Misc HWA fixes, add libchromaprint and the free libfdk_aac for better aac quality.

## How Has This Been Tested?
jellyfin-ffmpeg5 is a part of the upcoming Jellyfin 10.8.0 release, which has been tested for months.

Please cherry pick this commit to master/stable branch when 10.8.0 got released.

## Source / References:
https://github.com/jellyfin/jellyfin-ffmpeg/compare/v4.4.1-4...v5.0.1-5

