### PR TITLE
Update jellyfin-ffmpeg to jellyfin-ffmpeg5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,6 @@ LABEL maintainer="thelamer"
 ARG DEBIAN_FRONTEND="noninteractive"
 ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
-# set Intel iHD driver versions
-# https://dgpu-docs.intel.com/releases/index.html
-ARG INTEL_LIBVA_VER="2.13.0+i643~u20.04"
-ARG INTEL_GMM_VER="21.3.3+i643~u20.04"
-ARG INTEL_iHD_VER="21.4.1+i643~u20.04"
-
 RUN \
   echo "**** install packages ****" && \
   apt-get update && \
@@ -25,8 +19,6 @@ RUN \
   echo "**** install jellyfin *****" && \
   curl -s https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | apt-key add - && \
   echo 'deb [arch=amd64] https://repo.jellyfin.org/ubuntu focal main' > /etc/apt/sources.list.d/jellyfin.list && \
-  curl -s https://repositories.intel.com/graphics/intel-graphics.key | apt-key add - && \
-  echo 'deb [arch=amd64] https://repositories.intel.com/graphics/ubuntu focal main' > /etc/apt/sources.list.d/intel-graphics.list && \
   if [ -z ${JELLYFIN_RELEASE+x} ]; then \
     JELLYFIN="jellyfin-server"; \
   else \
@@ -35,9 +27,6 @@ RUN \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     at \
-    libva2="${INTEL_LIBVA_VER}" \
-    libigdgmm11="${INTEL_GMM_VER}" \
-    intel-media-va-driver-non-free="${INTEL_iHD_VER}" \
     ${JELLYFIN} \
     jellyfin-ffmpeg5 \
     jellyfin-web \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN \
     libigdgmm11="${INTEL_GMM_VER}" \
     intel-media-va-driver-non-free="${INTEL_iHD_VER}" \
     ${JELLYFIN} \
-    jellyfin-ffmpeg \
+    jellyfin-ffmpeg5 \
     jellyfin-web \
     libfontconfig1 \
     libfreetype6 \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -30,7 +30,7 @@ RUN \
   apt-get install -y --no-install-recommends \
     at \
     ${JELLYFIN} \
-    jellyfin-ffmpeg \
+    jellyfin-ffmpeg5 \
     jellyfin-web \
     libfontconfig1 \
     libfreetype6 \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -30,7 +30,7 @@ RUN \
   apt-get install -y --no-install-recommends \
     at \
     ${JELLYFIN} \
-    jellyfin-ffmpeg \
+    jellyfin-ffmpeg5 \
     jellyfin-web \
     libfontconfig1 \
     libfreetype6 \

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **11.06.22:** - Switch to upstream repo's ffmpeg5 build.
 * **05.01.22:** - Specify Intel iHD driver versions to avoid mismatched libva errors.
 * **25.12.21:** - Fix video device group perms error message.
 * **10.12.21:** - Rework readme, disable template sync.

--- a/package_versions.txt
+++ b/package_versions.txt
@@ -37,7 +37,7 @@ gzip1.10-0ubuntu4
 hostname3.23
 init-system-helpers1.57
 intel-media-va-driver-non-free21.4.1+i643~u20.04
-jellyfin-ffmpeg4.4.1-4-focal
+jellyfin-ffmpeg55.0.1-5-focal
 jellyfin-server10.8.0-1
 jellyfin-web10.8.0-1
 krb5-locales1.17-6ubuntu4.1

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -116,6 +116,7 @@ unraid_template_sync: false
 
 # changelog
 changelogs:
+  - { date: "11.06.22:", desc: "Switch to upstream repo's ffmpeg5 build." }
   - { date: "05.01.22:", desc: "Specify Intel iHD driver versions to avoid mismatched libva errors." }
   - { date: "25.12.21:", desc: "Fix video device group perms error message." }
   - { date: "10.12.21:", desc: "Rework readme, disable template sync." }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-jellyfin/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
The package name in our repos was updated to ensure backwards
compatibility with ffmpeg4 for 10.7.z and older. Thus, the latest
version for 10.8.0 is actually "jellyfin-ffmpeg5" instead. Update this
in the various dockerfiles and in the package_versions.txt file.

## Benefits of this PR and context:
Ensures that the latest FFMpeg version is available in the LSIO Jellyfin image.

## How Has This Been Tested?
Tested via official Jellyfin channels as working (e.g. `apt install`, functionality of FFMpeg 5.x, etc.)


## Source / References:
N/A
