### PR TITLE
Fix group permission for /dev/dri render devices - Fixes #150

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -116,6 +116,7 @@ unraid_template_sync: false
 
 # changelog
 changelogs:
+  - { date: "30.12.22:", desc: "Fix group permission for /dev/dri render devices." }
   - { date: "07.12.22:", desc: "Rebase master to Jammy, migrate to s6v3." }
   - { date: "11.06.22:", desc: "Switch to upstream repo's ffmpeg5 build." }
   - { date: "05.01.22:", desc: "Specify Intel iHD driver versions to avoid mismatched libva errors." }

--- a/root/etc/s6-overlay/s6-rc.d/init-jellyfin-video/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-jellyfin-video/run
@@ -1,6 +1,6 @@
 #!/usr/bin/with-contenv bash
 
-FILES=$(find /dev/dri /dev/dvb /dev/vchiq /dev/vc-mem /dev/video1? -type c -print 2>/dev/null)
+FILES=$(find /dev/dri /dev/dvb /dev/vchiq /dev/vc-mem /dev/video1? -type c -o -type f -print 2>/dev/null)
 
 for i in $FILES
 do


### PR DESCRIPTION
------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-jellyfin/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
Fix for #150.

## Benefits of this PR and context:
This should allow transcoding on /dev/dri render devices.

## How Has This Been Tested?
Tested locally on my docker container modifying the script and restarting the jellyfin service.
