### PR TITLE
Use User Supplied Owner for Web Files

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-jellyfin-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-jellyfin-config/run
@@ -12,3 +12,8 @@ lsiown abc:abc \
     /config/* \
     /config/data/transcodes \
     /transcode
+
+# Ensure that web-files are writable e.g. by user installed plugins.
+# https://github.com/linuxserver/docker-jellyfin/issues/182.
+lsiown -R abc:abc \
+    /usr/share/jellyfin/web


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-jellyfin/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:

This resolves a common pain point in using some common Jellyfin plugins, notably https://github.com/nicknsy/jellyscrub.

## Benefits of this PR and context:

This resolves https://github.com/linuxserver/docker-jellyfin/issues/182.

This also prevents having to run Jellyfin as root (the most common work around).

## How Has This Been Tested?

Yes.

```
docker build . -t test
docker run -it --rm test
```

```
docker exec -it <container id> bash
/usr/share/jellyfin# ls -las
total 144
  8 drwxr-xr-x 1 root root   4096 Feb 27 23:28 .
  8 drwxr-xr-x 1 root root   4096 Feb 27 23:28 ..
128 drwxr-xr-x 1 abc  abc  122880 Feb 27 23:28 web
```
