### PR TITLE
fix: take ownership of plugin directories

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -113,6 +113,7 @@ app_setup_block: |
 unraid_template_sync: false
 # changelog
 changelogs:
+  - {date: "12.09.23:", desc: "Take ownership of plugin directories."}
   - {date: "04.07.23:", desc: "Deprecate armhf. As announced [here](https://www.linuxserver.io/blog/a-farewell-to-arm-hf)"}
   - {date: "07.12.22:", desc: "Rebase master to Jammy, migrate to s6v3."}
   - {date: "11.06.22:", desc: "Switch to upstream repo's ffmpeg5 build."}

--- a/root/etc/s6-overlay/s6-rc.d/init-jellyfin-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-jellyfin-config/run
@@ -3,7 +3,7 @@
 
 # create directories
 mkdir -p \
-    /config/{log,data/transcodes,cache} \
+    /config/{log,data/plugins/configurations,data/transcodes,cache} \
     /data \
     /transcode
 
@@ -11,5 +11,7 @@ mkdir -p \
 lsiown abc:abc \
     /config \
     /config/* \
+    /config/data/plugins \
+    /config/data/plugins/configurations \
     /config/data/transcodes \
     /transcode


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-jellyfin/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This PR applies correct permissions to the jellyfin plugins directory, but more specifically the plugin configuration directories. Plugins for Jellyfin do not, and should not, supply the configuration directory, and should not be responsible for applying permissions on it, as if multiple plugins were added with the docker mod method, they could conflict with each other.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have not tested, the change is straight forward.


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://github.com/linuxserver/docker-mods/issues/753#issuecomment-1698198279